### PR TITLE
Issue #14 Using pdk.10.1.2.2.xip.io as default for the OpenShift TLD

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
   - [_test-admin_](#_test-admin_)
   - [Cluster admin](#cluster-admin)
 - [Misc](#misc)
-  - [How to expose OpenShift routes to the host](#how-to-expose-openshift-routes-to-the-host)
   - [How to sync an existing OpenShift project](#how-to-sync-an-existing-openshift-project)
   - [How to test webhooks locally](#how-to-test-webhooks-locally)
   - [How to debug EAP image](#how-to-debug-eap-image)
@@ -122,46 +121,6 @@ will attempt to overwrite _admin.kubeconfig_. Probably better to just define an 
 
 <a name="misc"></a>
 ## Misc
-
-<a name="how-to-expose-openshift-routes-to-the-host"></a>
-### How to expose OpenShift routes to the host
-
-Currently there is no solution for this on Windows (work on a automatic soltution
-is in progress), except manually editing the hosts file and adding entries of the
-form:
-
-```
-10.1.2.2 <routename>-<project>.router.default.svc.cluster.local
-```
-
-This will also work for OS X and Linux, however, in these cases you can also
-use the [Landrush](https://github.com/phinze/landrush) Vagrant plugin. Adding
-the following to your _Vagrantfile_ should get you sorted:
-
-```
-config.landrush.enabled = true
-config.landrush.tld = 'router.default.svc.cluster.local'
-config.landrush.guest_redirect_dns = false
-```
-
-This will work out of the boc on OS X. On Linux you alo need _dnsmasq_. Check
-the Landrush documentation.
-
-Another nice trick is to use [xip.io](http://xip.io/). This works on all OSes.
-You can either create your route already with a xip hostname:
-
-```
-oc expose service <service-name> --hostname=foo.10.1.2.2.xip.io
-```
-
-or you edit an existing route:
-
-```
-oc edit route/<route-name>
-```
-
-and change the hostname to an xip one. In both cases the app will then
-be accessible via the xip route.
 
 <a name="how-to-sync-an-existing-openshift-project"></a>
 ### How to sync an existing OpenShift project

--- a/cdk-v2/Vagrantfile
+++ b/cdk-v2/Vagrantfile
@@ -76,18 +76,6 @@ Vagrant.configure(2) do |config|
     raise Vagrant::Errors::VagrantError.new, NO_ADBINFO_ERROR
   end
 
-  # We need a way to expose the created OpenShift routes to the host
-  # For now there is no Windows solution. For OS X and Linux enable Landrush
-  if ! OS.windows? then
-  	if Vagrant.has_plugin?("landrush") then
-      config.landrush.enabled = true
-      config.landrush.tld = 'router.default.svc.cluster.local'
-      config.landrush.guest_redirect_dns = false
-    else
-      puts "To expose routes to host install Landrush plugin - 'vagrant install landrush'"
-    end
-  end
-
   config.vm.provision :shell, :path => "./scripts/configure_docker.sh", :args => "#{REDHAT_DOCKER_REGISTRY} #{REDHAT_INTERNAL_DOCKER_REGISTRY}"
   config.vm.provision :shell, :path => "./scripts/configure_ose.sh", :args => "#{REDHAT_DOCKER_REGISTRY} #{PUBLIC_ADDRESS}"
 

--- a/cdk-v2/scripts/configure_docker.sh
+++ b/cdk-v2/scripts/configure_docker.sh
@@ -15,8 +15,8 @@ set -o nounset
 # set -o xtrace
 
 if [ -f /opt/docker_selinux ]; then
-  echo "[INFO] Skipping Docker configuration. Already done."
-  exit 0;
+	echo "[INFO] Skipping Docker configuration. Already done."
+	exit 0;
 fi
 
 # Do some SeLinux wodoo

--- a/cdk-v2/scripts/configure_ose.sh
+++ b/cdk-v2/scripts/configure_ose.sh
@@ -14,64 +14,110 @@ export ORIGIN_DIR="/var/lib/origin"
 export OPENSHIFT_DIR=${ORIGIN_DIR}/openshift.local.config/master
 export KUBECONFIG=${OPENSHIFT_DIR}/admin.kubeconfig
 
+########################################################################
+# Helper function to start OpenShift as container
+#
+# All passed paramters are passed through ti
+########################################################################
+start_ose() {
+	docker run -d --name "ose" --privileged --net=host --pid=host \
+    	-v /:/rootfs:ro \
+     	-v /var/run:/var/run:rw \
+     	-v /sys:/sys:ro \
+     	-v /var/lib/docker:/var/lib/docker:rw \
+     	-v ${ORIGIN_DIR}/openshift.local.volumes:${ORIGIN_DIR}/openshift.local.volumes:z \
+     	-v ${ORIGIN_DIR}/openshift.local.config:${ORIGIN_DIR}/openshift.local.config:z \
+     	-v ${ORIGIN_DIR}/openshift.local.etcd:${ORIGIN_DIR}/openshift.local.etcd:z \
+     openshift3/ose start "$@"
+}
+
+########################################################################
+# Helper function to remove existing ose container
+########################################################################
+rm_ose_container() {
+	if docker inspect ose &>/dev/null; then
+		echo "[INFO] Removing existing OpenShift container ..."
+		docker rm -f -v ose > /dev/null 2>&1
+	fi
+}
+
+########################################################################
+# Main
+########################################################################
 # Check whether a OpenShift image exists and if not pull and tag it
 docker inspect openshift3/ose &>/dev/null
-if [ $? -eq 0 ]
-then
-  echo "[INFO] Skipping pull of OpenShift image "
+if [ $? -eq 0 ]; then
+	echo "[INFO] Skipping pull of OpenShift image "
 else
-  echo "[INFO] Pulling ${OSE_IMAGE_NAME} Docker image ..."
-  docker pull $1/${OSE_IMAGE_NAME}
-  docker tag $1/${OSE_IMAGE_NAME} openshift3/ose
+	echo "[INFO] Pulling ${OSE_IMAGE_NAME} Docker image ..."
+	docker pull $1/${OSE_IMAGE_NAME}
+	docker tag $1/${OSE_IMAGE_NAME} openshift3/ose
 fi
 
+# Copy OpenShift CLI tools to the VM
 binaries=(oc oadm)
 for n in ${binaries[@]}; do
-  [ -f /usr/bin/${n} ] && continue
-  echo "[INFO] Copying the OpenShift '${n}' binary to host /usr/bin/${n}"
-  docker run --rm --entrypoint=/bin/cat openshift3/ose /usr/bin/${n} > /usr/bin/${n}
-  chmod +x /usr/bin/${n}
+	[ -f /usr/bin/${n} ] && continue
+	echo "[INFO] Copying the OpenShift '${n}' binary to host /usr/bin/${n}"
+	docker run --rm --entrypoint=/bin/cat openshift3/ose /usr/bin/${n} > /usr/bin/${n}
+	chmod +x /usr/bin/${n}
 done
 echo "export OPENSHIFT_DIR=#{ORIGIN_DIR}/openshift.local.config/master" > /etc/profile.d/openshift.sh
 
-# Start OpenShift
+# Check whether OpenShift is running, if so skip any further provisioning
 state=$(docker inspect -f "{{.State.Running}}" ose 2>/dev/null)
-if [ "${state}" == "true" ]
-then
-  echo "[INFO] Skipping OpenShift configuration. Already running"
-  exit 0;
+if [ "${state}" == "true" ]; then
+	echo "[INFO] Skipping OpenShift configuration. Already running"
+	exit 0;
 fi
 
-if docker inspect ose &>/dev/null
-then
-  echo "[INFO] Removing previously started OpenShift container ..."
-  docker rm -f -v ose > /dev/null 2>&1
-fi
-
-echo "[INFO] Starting OpenShift server ..."
+# In a re-provision scenario we want to make sure the old container is removed
+rm_ose_container
 
 # Prepare directories for bind-mounting
 dirs=(openshift.local.volumes openshift.local.config openshift.local.etcd)
 for d in ${dirs[@]}; do
-  mkdir -p ${ORIGIN_DIR}/${d} && chcon -Rt svirt_sandbox_file_t ${ORIGIN_DIR}/${d}
+	mkdir -p ${ORIGIN_DIR}/${d} && chcon -Rt svirt_sandbox_file_t ${ORIGIN_DIR}/${d}
 done
 
-docker run -d --name "ose" --privileged --net=host --pid=host \
-     -v /:/rootfs:ro \
-     -v /var/run:/var/run:rw \
-     -v /sys:/sys:ro \
-     -v /var/lib/docker:/var/lib/docker:rw \
-     -v ${ORIGIN_DIR}/openshift.local.volumes:${ORIGIN_DIR}/openshift.local.volumes:z \
-     -v ${ORIGIN_DIR}/openshift.local.config:${ORIGIN_DIR}/openshift.local.config:z \
-     -v ${ORIGIN_DIR}/openshift.local.etcd:${ORIGIN_DIR}/openshift.local.etcd:z \
-     openshift3/ose start \
-      --master="https://${2}:8443" \
-      --etcd-dir="${ORIGIN_DIR}/openshift.local.etcd" \
-      --cors-allowed-origins=.* > /dev/null 2>&1
+# First start OpenShift to just write the config files
+echo "[INFO] Preparing OpenShift config ..."
+start_ose --write-config=${ORIGIN_DIR}/openshift.local.config
+for i in {1..5}; do
+  if [ ! -f ${OPENSHIFT_DIR}/master-config.yaml ]; then
+    echo "Waiting for OpenShift config files to be created ..."
+    sleep 5
+  else
+    break
+  fi
+done
+if [ ! -f ${OPENSHIFT_DIR}/master-config.yaml ]; then
+  >&2 echo "[ERROR] Unable to create OpenShift config files"
+  docker logs ose
+  exit 1
+fi
 
-sleep 15 # Give OpenShift 15 seconds to start
+# Now we need to make some adjustments to the config
+sed -i.orig -e "s/\(.*masterPublicURL:\).*/\1 https:\/\/$2:8443/" ${OPENSHIFT_DIR}/master-config.yaml
+sed -i.orig -e "s/\(.*publicURL:\).*/\1 https:\/\/$2:8443\/console\//" ${OPENSHIFT_DIR}/master-config.yaml
+sed -i.orig -e "s/\(.*assetPublicURL:\).*/\1 https:\/\/$2:8443\/console\//" ${OPENSHIFT_DIR}/master-config.yaml
+sed -i.orig -e "s/\(.*subdomain:\).*/\1 pdk.10.1.2.2.xip.io/" ${OPENSHIFT_DIR}/master-config.yaml
+
+# Remove the container
+rm_ose_container
+
+# Now we start the server pointing to the prepared config files
+echo "[INFO] Starting OpenShift server ..."
+start_ose --master-config="${ORIGIN_DIR}/openshift.local.config/master/master-config.yaml" \
+--node-config="${ORIGIN_DIR}/openshift.local.config/node-localhost.localdomain/node-config.yaml" > /dev/null 2>&1
+
+# Give OpenShift 15 seconds to start
+sleep 15
+
+# Makte sure kubeconfig is writable
 chmod go+r ${KUBECONFIG}
 
+# Check whether OpenShift is running
 state=$(docker inspect -f "{{.State.Running}}" ose)
 if [[ "${state}" != "true" ]]; then
   >&2 echo "[ERROR] OpenShift failed to start:"
@@ -99,10 +145,9 @@ if [ ! -f ${ORIGIN_DIR}/configured.router ]; then
   touch ${ORIGIN_DIR}/configured.router
 fi
 
-# Downloading application templates
+# Downloading OpenShift application templates
 EXAMPLES_BASE=/opt/openshift/templates
-if [ ! -d "${EXAMPLES_BASE}"  ]
-then
+if [ ! -d "${EXAMPLES_BASE}"  ]; then
   echo "[INFO] Downloading OpenShift and xPaaS templates ..."
   temp_dir=$(mktemp -d)
   pushd ${temp_dir} >/dev/null
@@ -130,8 +175,8 @@ else
   echo "[INFO] Skipping download of OpenShift templates. ${EXAMPLES_BASE} already exists"
 fi
 
-if [ ! -f ${ORIGIN_DIR}/configured.templates ]
-then
+# Importing downloaded templates into OpenShift
+if [ ! -f ${ORIGIN_DIR}/configured.templates ]; then
   echo "[INFO] Installing OpenShift templates ..."
   for name in $(find /opt/openshift/templates -name '*.json')
   do
@@ -140,8 +185,8 @@ then
   touch ${ORIGIN_DIR}/configured.templates
 fi
 
-if [ ! -f ${ORIGIN_DIR}/configured.user ]
-then
+# Configuring a test-admin user which can view the detault namespace
+if [ ! -f ${ORIGIN_DIR}/configured.user ]; then
   echo "[INFO] Creating 'test-admin' user and 'test' project ..."
   oadm policy add-role-to-user view test-admin --config=${OPENSHIFT_DIR}/admin.kubeconfig
   oc login https://${2}:8443 -u test-admin -p test \


### PR DESCRIPTION
This will make sure that OpenShift routes are now per default of the form \<app\>-\<project\>.pdk.10.1.2.2.xip.io.
This will make DNS resolution work across all OS.