### PR TITLE
Add .cdk marker to enable JBDS automatic detection

### DIFF
--- a/cdk-v2/.cdk
+++ b/cdk-v2/.cdk
@@ -1,0 +1,2 @@
+openshift.auth.scheme=Basic
+openshift.auth.username=test-admin


### PR DESCRIPTION
a .cdk marker file is used by JBoss Tools / JBDS to automatcially detect the CDK and set up a server adapter. See https://issues.jboss.org/browse/JBIDE-21173

cc @robstryker