### PR TITLE
Issue #66 Improving plugin requirement check

### DIFF
--- a/cdk-v2-ose-3-2/Vagrantfile
+++ b/cdk-v2-ose-3-2/Vagrantfile
@@ -36,8 +36,16 @@ SUBSCRIPTION_INFO = "
     $ export SUB_PASSWORD=password
   "
 
-NO_SERVICE_MANAGER_ERROR = "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
-NO_VAGRANT_REGISTRATION_ERROR = "vagrant-registration plugin is not installed, run `vagrant plugin install vagrant-registration` to install the plugin."
+REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-registration)
+message = ->(name) { "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it." }
+errors = []
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each {|plugin| errors << message.call(plugin) unless Vagrant.has_plugin?(plugin) }
+if errors.size > 1
+  raise errors.inject(''){|msg, e| msg += "\n * #{e}" }
+else
+  raise errors.first
+end
 
 Vagrant.configure(2) do |config|
 
@@ -61,14 +69,6 @@ Vagrant.configure(2) do |config|
       end
 
       cdk.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}"
-
-      unless Vagrant.has_plugin?("vagrant-service-manager")
-        raise Vagrant::Errors::VagrantError.new, NO_SERVICE_MANAGER_ERROR
-      end
-
-      unless Vagrant.has_plugin?('vagrant-registration')
-        raise Vagrant::Errors::VagrantError.new, NO_VAGRANT_REGISTRATION_ERROR
-      end
 
       if ENV.has_key?('SUB_USERNAME') && ENV.has_key?('SUB_PASSWORD')
         cdk.registration.username = ENV['SUB_USERNAME']

--- a/cdk-v2/Vagrantfile
+++ b/cdk-v2/Vagrantfile
@@ -36,8 +36,13 @@ SUBSCRIPTION_INFO = "
     $ export SUB_PASSWORD=password
   "
 
-NO_SERVICE_MANAGER_ERROR = "vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install the plugin."
-NO_VAGRANT_REGISTRATION_ERROR = "vagrant-registration plugin is not installed, run `vagrant plugin install vagrant-registration` to install the plugin."
+REQUIRED_PLUGINS = %w(vagrant-service-manager vagrant-registration)
+message = ->(name) { "#{name} plugin is not installed, run `vagrant plugin install #{name}` to install it." }
+errors = []
+# Validate and collect error message if plugin is not installed
+REQUIRED_PLUGINS.each {|plugin| errors << message.call(plugin) unless Vagrant.has_plugin?(plugin) }
+msg = errors.size > 1 ? "Errors: \n* #{errors.join("\n* ")}" : "Error: #{errors.first}"
+raise Vagrant::Errors::VagrantError.new, msg
 
 Vagrant.configure(2) do |config|
 
@@ -61,14 +66,6 @@ Vagrant.configure(2) do |config|
       end
 
       cdk.vm.network "private_network", ip: "#{PUBLIC_ADDRESS}"
-
-      unless Vagrant.has_plugin?("vagrant-service-manager")
-        raise Vagrant::Errors::VagrantError.new, NO_SERVICE_MANAGER_ERROR
-      end
-
-      unless Vagrant.has_plugin?('vagrant-registration')
-        raise Vagrant::Errors::VagrantError.new, NO_VAGRANT_REGISTRATION_ERROR
-      end
 
       if ENV.has_key?('SUB_USERNAME') && ENV.has_key?('SUB_PASSWORD')
         cdk.registration.username = ENV['SUB_USERNAME']
@@ -108,4 +105,3 @@ Vagrant.configure(2) do |config|
       SHELL
     end
 end
-


### PR DESCRIPTION
Fix #66
* Scale up to check existence of multiple plugins
* Update "REQUIRED_PLUGINS" to add new required plugins
* For multiple errors it list as:
  * Error message one
  * Error message two
  * ... many more

Eg:
For single error:
```
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /home/budhram/redhat/adb-atomic-developer-bundle/components/centos/centos-docker-base-setup/Vagrantfile
Line number: 13
Message: RuntimeError: vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install it.
```
For multiple errors:
```
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
a syntax error.

Path: /home/budhram/redhat/adb-atomic-developer-bundle/components/centos/centos-docker-base-setup/Vagrantfile
Line number: 11
Message: RuntimeError: 
 * vagrant-service-manager plugin is not installed, run `vagrant plugin install vagrant-service-manager` to install it.
 * vagrant-registration plugin is not installed, run `vagrant plugin install vagrant-registration` to install it.
```